### PR TITLE
fix(lsp): complete tags and attributes after element text

### DIFF
--- a/src/lsp/features/autocomplete.zig
+++ b/src/lsp/features/autocomplete.zig
@@ -52,7 +52,7 @@ pub fn complete(
 
 fn detectContext(arena: std.mem.Allocator, source: []const u8, offset: u32) ?Context {
     if (detectFromParse(arena, source, offset)) |ctx| return ctx;
-    return detectFromText(source, offset);
+    return detectFromText(source, offset, false);
 }
 
 fn detectFromParse(arena: std.mem.Allocator, source: []const u8, offset: u32) ?Context {
@@ -60,11 +60,12 @@ fn detectFromParse(arena: std.mem.Allocator, source: []const u8, offset: u32) ?C
     defer parse.deinit(arena);
 
     const root = parse.tree.rootNode();
+    const in_markup = parseSaysMarkupLt(root, source, offset);
     const node = root.descendantForByteRange(offset, offset) orelse {
-        return detectFromText(source, offset);
+        return detectFromText(source, offset, in_markup);
     };
 
-    if (!inZxMarkup(node)) return detectFromText(source, offset);
+    if (!inZxMarkup(node)) return detectFromText(source, offset, in_markup);
 
     var current: ?@TypeOf(node) = node;
     while (current) |n| : (current = n.parent()) {
@@ -108,16 +109,28 @@ fn detectFromParse(arena: std.mem.Allocator, source: []const u8, offset: u32) ?C
         }
     }
 
-    return detectFromText(source, offset);
+    return detectFromText(source, offset, in_markup);
 }
 
-fn detectFromText(source: []const u8, offset: u32) ?Context {
+/// True when the parser places the `<` nearest before `offset` inside ZX
+/// markup. A tag that is still being typed lands under an `ERROR` node, so the
+/// tag itself carries no context, but the token *before* the `<` is still
+/// classified - and that is enough to tell markup apart from a Zig `<`.
+fn parseSaysMarkupLt(root: anytype, source: []const u8, offset: u32) bool {
+    if (offset == 0 or offset > source.len) return false;
+    const lt = std.mem.lastIndexOfScalar(u8, source[0..offset], '<') orelse return false;
+    if (lt == 0) return false;
+    const prev = root.descendantForByteRange(@intCast(lt - 1), @intCast(lt)) orelse return false;
+    return inZxMarkup(prev);
+}
+
+fn detectFromText(source: []const u8, offset: u32, in_markup: bool) ?Context {
     if (offset == 0) return null;
     const before = source[0..offset];
 
     const lt = std.mem.lastIndexOfScalar(u8, before, '<') orelse return null;
     const after_lt = before[lt + 1 ..];
-    if (!looksLikeMarkupLt(source, lt)) return null;
+    if (!in_markup and !looksLikeMarkupLt(source, lt)) return null;
     if (std.mem.indexOfScalar(u8, after_lt, '>') != null) return null;
 
     const closing = after_lt.len > 0 and after_lt[0] == '/';
@@ -142,6 +155,8 @@ fn detectFromText(source: []const u8, offset: u32) ?Context {
     };
 }
 
+/// Text-only fallback for when the parse tree cannot classify the `<`:
+/// markup children always start right after `(` or a preceding `>`.
 fn looksLikeMarkupLt(source: []const u8, lt: usize) bool {
     var i = lt;
     while (i > 0) {
@@ -391,6 +406,7 @@ fn inZxMarkup(node: anytype) bool {
             .zx_start_tag,
             .zx_end_tag,
             .zx_child,
+            .zx_text,
             => return true,
             else => {},
         }

--- a/test/cli/lsp.zig
+++ b/test/cli/lsp.zig
@@ -307,3 +307,131 @@ test "hover > lowercase button still shows HTML docs" {
     const md = (try html_hover.hoverMarkdown(arena, src, off)) orelse return error.NoHover;
     try testing.expect(std.mem.indexOf(u8, md, "<button>") != null);
 }
+
+fn completionLabels(arena: std.mem.Allocator, src: []const u8, offset: u32) ![]const []const u8 {
+    const result = (try html_complete.complete(arena, src, offset)) orelse return &.{};
+    const items = switch (result) {
+        .completion_list => |list| list.items,
+        .completion_items => |items| items,
+    };
+    const labels = try arena.alloc([]const u8, items.len);
+    for (items, 0..) |item, i| labels[i] = item.label;
+    return labels;
+}
+
+fn hasLabel(labels: []const []const u8, want: []const u8) bool {
+    for (labels) |label| {
+        if (std.mem.eql(u8, label, want)) return true;
+    }
+    return false;
+}
+
+test "completion > tag name after element text" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hello <b
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "b"));
+    try testing.expect(hasLabel(labels, "br"));
+}
+
+test "completion > tag name after expression block" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>{name} <str
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "strong"));
+}
+
+test "completion > bare < after element text" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hello <
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "span"));
+}
+
+test "completion > attribute after element text" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hello <a hr
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "href"));
+    try testing.expect(hasLabel(labels, "hreflang"));
+}
+
+test "completion > builtin attribute after element text" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hello <Counter @rend
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "@rendering"));
+}
+
+test "completion > closing tag after element text" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hello </
+    ;
+    const labels = try completionLabels(arena, src, @intCast(src.len));
+    try testing.expect(hasLabel(labels, "p"));
+}
+
+test "completion > zig less-than after markup stays null" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // A `<` used as a comparison must not be mistaken for a tag, even in a file
+    // that also contains ZX markup.
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>hi</p>);
+        \\}
+        \\
+        \\fn lt(x: usize, y: usize) bool {
+        \\    return x <y
+    ;
+    try testing.expect((try html_complete.complete(arena, src, @intCast(src.len))) == null);
+}
+
+test "completion > zig less-than inside expression block stays null" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const src =
+        \\pub fn Page(a: zx.Allocator) zx.Component {
+        \\    return (<p @allocator={a}>{if (x <y
+    ;
+    try testing.expect((try html_complete.complete(arena, src, @intCast(src.len))) == null);
+}

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -75,8 +75,10 @@ export default defineConfig({
       cwd: '../../',
       url: 'http://localhost:3000',
       reuseExistingServer: process.env.TEMPLATE_TESTS || !process.env.CI,
-      // Wait for 5 mins for the server to start, since zig build can be slow on the first run
-      timeout: 1000 * 60 * 5,
+      // First `zig build dev` compiles the site, playground wasm, and lazy
+      // deps (zls, lunasvg, …). That regularly exceeds 5 minutes on a cold
+      // GitHub runner, so wait 15 minutes before treating startup as failed.
+      timeout: 1000 * 60 * 15,
     },
   }),
 });


### PR DESCRIPTION
## Summary

`zx lsp` gave no completions for markup that follows text or an expression block, which is most inline markup:

```zx
<p @allocator={a}>hello <b        // no tag completions
<p @allocator={a}>hello <a hr     // no attribute completions
<p @allocator={a}>{name} <str     // no tag completions
```

Completion now works in those positions, and Zig `<` comparisons still return nothing.

## Problem

Completions only appeared when the `<` came directly after `(` or a preceding `>`:

| source (cursor at end)          | before | after            |
| ------------------------------- | ------ | ---------------- |
| `return (<di`                   | `div`… | `div`…           |
| `return (<div><sp`              | `span` | `span`           |
| `return (<p>hello <b`           | –      | `b`, `br`, `body`… |
| `return (<p>hello <`            | –      | all tags         |
| `return (<p>hello <a hr`        | –      | `href`, `hreflang` |
| `return (<p>{name} <str`        | –      | `strong`         |
| `return (<p>hello </`           | –      | closing tags     |

## Root Cause

`detectContext` first asks the parse tree. A tag that is still being typed is incomplete, so tree-sitter puts it under an `ERROR` node whose ancestors carry no ZX kinds — `inZxMarkup` returns false and detection falls through to the text heuristic.

That heuristic, `looksLikeMarkupLt`, accepted a `<` only when the previous non-whitespace byte was `(` or `>`. After element text (`hello <b`) or an expression block (`{name} <b`) the previous byte is neither, so it bailed out and `complete` returned `null`.

## Solution

The tag being typed is unparseable, but the token *before* the `<` still is: for `<p>hello <b` tree-sitter reports `zx_text[56..62]` for `hello `, and for `const x = a <b` it reports `identifier` inside `binary_expression`. That is exactly the signal needed.

- `parseSaysMarkupLt` looks up the token ending right before the `<` and reports whether it is ZX markup.
- `detectFromText` takes that as an `in_markup` flag and skips the `(`/`>` heuristic when it is set. The heuristic is kept as the fallback for when there is no usable parse, so no previously working case changes.
- `zx_text` is added to `inZxMarkup` so element text content counts as markup.

The change is additive — it only turns previously-`null` positions into completions — so the existing negative cases are unaffected.

## Testing

`zig build test` with Zig `0.17.0-dev.1465+8b2d0ce21` (the version pinned in CI):

- `599 pass, 0 fail, 11 skipped` (baseline on `main` was `591 pass, 0 fail, 11 skipped`)
- `zig build` succeeds
- `zig fmt --check` clean on both changed files

8 tests added to `test/cli/lsp.zig`. The 6 positive ones fail on `main` and pass with the fix:

```
✗ completion > tag name after element text
✗ completion > tag name after expression block
✗ completion > bare < after element text
✗ completion > attribute after element text
✗ completion > builtin attribute after element text
✗ completion > closing tag after element text
```

The 2 negative ones pass both before and after, pinning down that Zig comparisons are not mistaken for tags:

- `completion > zig less-than after markup stays null` — `return x <y` in a file that also contains markup
- `completion > zig less-than inside expression block stays null` — `{if (x <y` inside a ZX expression block

## Related Issue

Related to #101 (`fix(lsp): source mapping and auto complete issues`) — this covers the auto complete half.
