### PR TITLE
fix(lsp): honour the negotiated position encoding

### DIFF
--- a/src/lsp/Handler.zig
+++ b/src/lsp/Handler.zig
@@ -7,6 +7,7 @@ const lang = @import("lang");
 const zx_info = @import("zx_info");
 const html_hover = @import("features/hover.zig");
 const html_complete = @import("features/autocomplete.zig");
+const text = @import("text.zig");
 pub const Zls = @import("Handler/Zls.zig");
 
 const ByteRange = struct {
@@ -382,6 +383,7 @@ fn filterInlayHintsForZxBlocks(
     arena: std.mem.Allocator,
     hints: []const lsp.types.flat.InlayHint,
     state: *const ZxFileState,
+    encoding: lsp.offsets.Encoding,
 ) ![]const lsp.types.flat.InlayHint {
     if (hints.len == 0 or state.zx_block_ranges.len == 0) return hints;
 
@@ -390,10 +392,7 @@ fn filterInlayHintsForZxBlocks(
     try filtered.ensureTotalCapacity(arena, hints.len);
 
     for (hints) |hint| {
-        const offset = positionToOffset(state.source, hint.position) orelse {
-            try filtered.append(arena, hint);
-            continue;
-        };
+        const offset = text.positionToOffset(state.source, hint.position, encoding);
 
         if (offsetInAnyRange(offset, state.zx_block_ranges)) continue;
         try filtered.append(arena, hint);
@@ -612,7 +611,13 @@ pub fn @"textDocument/didChange"(
                     needs_free = false;
                 },
                 .text_document_content_change_partial => |inc| {
-                    const new_text = applyIncrementalChange(handler.allocator, full_text, inc.range, inc.text) catch {
+                    const new_text = text.applyIncrementalChange(
+                        handler.allocator,
+                        full_text,
+                        inc.range,
+                        inc.text,
+                        handler.offset_encoding,
+                    ) catch {
                         continue;
                     };
                     if (needs_free) handler.allocator.free(full_text);
@@ -636,50 +641,6 @@ pub fn @"textDocument/didChange"(
         return;
     }
     handler.sendNotificationSync(arena, "textDocument/didChange", params);
-}
-
-fn applyIncrementalChange(
-    allocator: std.mem.Allocator,
-    source: []const u8,
-    range: lsp.types.flat.Range,
-    new_text: []const u8,
-) ![]const u8 {
-    const start_offset = positionToOffset(source, range.start) orelse return error.InvalidRange;
-    const end_offset = positionToOffset(source, range.end) orelse return error.InvalidRange;
-
-    const new_len = start_offset + new_text.len + (source.len - end_offset);
-    const result = try allocator.alloc(u8, new_len);
-    @memcpy(result[0..start_offset], source[0..start_offset]);
-    @memcpy(result[start_offset..][0..new_text.len], new_text);
-    @memcpy(result[start_offset + new_text.len ..], source[end_offset..]);
-    return result;
-}
-
-fn positionToOffset(source: []const u8, pos: lsp.types.flat.Position) ?usize {
-    var line: u32 = 0;
-    var i: usize = 0;
-    while (line < pos.line and i < source.len) {
-        if (source[i] == '\n') line += 1;
-        i += 1;
-    }
-    if (line != pos.line) return null;
-    const offset = i + pos.character;
-    if (offset > source.len) return null;
-    return offset;
-}
-
-fn offsetToPosition(source: []const u8, offset: u32) lsp.types.flat.Position {
-    var line: u32 = 0;
-    var line_start: usize = 0;
-    const limit = @min(offset, source.len);
-    var i: usize = 0;
-    while (i < limit) : (i += 1) {
-        if (source[i] == '\n') {
-            line += 1;
-            line_start = i + 1;
-        }
-    }
-    return .{ .line = line, .character = @intCast(limit - line_start) };
 }
 
 pub fn @"textDocument/didSave"(
@@ -747,7 +708,7 @@ fn htmlHover(
     params: lsp.types.flat.HoverParams,
 ) ?lsp.types.flat.Hover {
     const state = handler.zx_files.get(params.textDocument.uri) orelse return null;
-    const offset = positionToOffset(state.source, params.position) orelse return null;
+    const offset = text.positionToOffset(state.source, params.position, handler.offset_encoding);
 
     const result = html_hover.hover(arena, state.source, @intCast(offset)) catch return null;
     const hover = result orelse return null;
@@ -760,8 +721,8 @@ fn htmlHover(
             },
         },
         .range = .{
-            .start = offsetToPosition(state.source, hover.start_byte),
-            .end = offsetToPosition(state.source, hover.end_byte),
+            .start = text.offsetToPosition(state.source, hover.start_byte, handler.offset_encoding),
+            .end = text.offsetToPosition(state.source, hover.end_byte, handler.offset_encoding),
         },
     };
 }
@@ -785,7 +746,7 @@ fn htmlComplete(
     params: lsp.types.flat.CompletionParams,
 ) ?lsp.types.completion.Result {
     const state = handler.zx_files.get(params.textDocument.uri) orelse return null;
-    const offset = positionToOffset(state.source, params.position) orelse return null;
+    const offset = text.positionToOffset(state.source, params.position, handler.offset_encoding);
     return html_complete.complete(arena, state.source, @intCast(offset)) catch null;
 }
 
@@ -916,7 +877,7 @@ pub fn @"textDocument/inlayHint"(
         const hints = handler.sendRequestSync(arena, "textDocument/inlayHint", new_params) catch null;
         if (hints) |backing_hints| {
             if (handler.zx_files.get(params.textDocument.uri)) |state| {
-                return try filterInlayHintsForZxBlocks(arena, backing_hints, &state);
+                return try filterInlayHintsForZxBlocks(arena, backing_hints, &state, handler.offset_encoding);
             }
         }
         return hints;
@@ -958,7 +919,7 @@ pub fn @"textDocument/formatting"(
                 return null;
             }
 
-            const end = offsetToPosition(state.source, @intCast(state.source.len));
+            const end = text.offsetToPosition(state.source, state.source.len, handler.offset_encoding);
             const edits = try arena.alloc(lsp.types.flat.TextEdit, 1);
             edits[0] = .{
                 .range = .{

--- a/src/lsp/root.zig
+++ b/src/lsp/root.zig
@@ -2,6 +2,7 @@
 pub const hover = @import("features/hover.zig");
 pub const complete = @import("features/autocomplete.zig");
 pub const docs = @import("data/elements.zig");
+pub const text = @import("text.zig");
 
 test {
     _ = hover;

--- a/src/lsp/text.zig
+++ b/src/lsp/text.zig
@@ -1,0 +1,44 @@
+//! Position/offset helpers for LSP text documents.
+//!
+//! `Position.character` counts code units of the encoding negotiated during
+//! `initialize` (UTF-16 unless the client asks for something else), not bytes,
+//! so every conversion has to go through that `Encoding`.
+
+const std = @import("std");
+const lsp = @import("lsp");
+
+pub const Encoding = lsp.offsets.Encoding;
+pub const Position = lsp.types.flat.Position;
+pub const Range = lsp.types.flat.Range;
+
+/// Byte offset of `pos` in `source`. Positions past the end of their line (or
+/// past the end of the document) are clamped.
+pub fn positionToOffset(source: []const u8, pos: Position, encoding: Encoding) usize {
+    return lsp.offsets.positionToIndex(source, pos, encoding);
+}
+
+/// Position of the byte at `offset` in `source`.
+pub fn offsetToPosition(source: []const u8, offset: usize, encoding: Encoding) Position {
+    return lsp.offsets.indexToPosition(source, @min(offset, source.len), encoding);
+}
+
+/// Apply one `textDocument/didChange` incremental edit and return the new
+/// document. Caller owns the returned memory.
+pub fn applyIncrementalChange(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    range: Range,
+    new_text: []const u8,
+    encoding: Encoding,
+) ![]const u8 {
+    const start_offset = positionToOffset(source, range.start, encoding);
+    const end_offset = positionToOffset(source, range.end, encoding);
+    if (start_offset > end_offset) return error.InvalidRange;
+
+    const new_len = start_offset + new_text.len + (source.len - end_offset);
+    const result = try allocator.alloc(u8, new_len);
+    @memcpy(result[0..start_offset], source[0..start_offset]);
+    @memcpy(result[start_offset..][0..new_text.len], new_text);
+    @memcpy(result[start_offset + new_text.len ..], source[end_offset..]);
+    return result;
+}

--- a/test/cli/lsp.zig
+++ b/test/cli/lsp.zig
@@ -307,3 +307,142 @@ test "hover > lowercase button still shows HTML docs" {
     const md = (try html_hover.hoverMarkdown(arena, src, off)) orelse return error.NoHover;
     try testing.expect(std.mem.indexOf(u8, md, "<button>") != null);
 }
+
+const lsp_text = html.text;
+
+test "text > positionToOffset counts utf-16 code units" {
+    // `é` is two bytes but one utf-16 code unit, so the byte offset of the
+    // character after "Café" is 5 while its utf-16 column is 4.
+    const src = "Café x\nsecond\n";
+
+    try testing.expectEqual(
+        @as(usize, 5),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 4 }, .@"utf-16"),
+    );
+    try testing.expectEqual(
+        @as(usize, 4),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 4 }, .@"utf-8"),
+    );
+    try testing.expectEqual(
+        @as(usize, 5),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 4 }, .@"utf-32"),
+    );
+}
+
+test "text > positionToOffset handles surrogate pairs" {
+    // `🠁` is four bytes and two utf-16 code units.
+    const src = "a🠁b\n";
+
+    try testing.expectEqual(
+        @as(usize, 5),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 3 }, .@"utf-16"),
+    );
+    try testing.expectEqual(
+        @as(usize, 5),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 2 }, .@"utf-32"),
+    );
+}
+
+test "text > positionToOffset clamps to the end of the line" {
+    const src = "ab\ncdef\n";
+
+    // A column past the end of line 0 must not spill into line 1.
+    try testing.expectEqual(
+        @as(usize, 2),
+        lsp_text.positionToOffset(src, .{ .line = 0, .character = 40 }, .@"utf-16"),
+    );
+    try testing.expectEqual(
+        @as(usize, 3),
+        lsp_text.positionToOffset(src, .{ .line = 1, .character = 0 }, .@"utf-16"),
+    );
+}
+
+test "text > offsetToPosition counts utf-16 code units" {
+    const src = "Café x\nsecond\n";
+
+    const pos = lsp_text.offsetToPosition(src, 5, .@"utf-16");
+    try testing.expectEqual(@as(u32, 0), pos.line);
+    try testing.expectEqual(@as(u32, 4), pos.character);
+
+    const bytes = lsp_text.offsetToPosition(src, 5, .@"utf-8");
+    try testing.expectEqual(@as(u32, 5), bytes.character);
+
+    // Byte 7 is the newline that ends line 0; line 1 starts at byte 8.
+    const eol = lsp_text.offsetToPosition(src, 7, .@"utf-16");
+    try testing.expectEqual(@as(u32, 0), eol.line);
+    try testing.expectEqual(@as(u32, 6), eol.character);
+
+    const second = lsp_text.offsetToPosition(src, 8, .@"utf-16");
+    try testing.expectEqual(@as(u32, 1), second.line);
+    try testing.expectEqual(@as(u32, 0), second.character);
+}
+
+test "text > offsetToPosition roundtrips through positionToOffset" {
+    const src = "<p>Café ↉ x</p>\n<b>🠁</b>\n";
+
+    var offset: usize = 0;
+    while (offset <= src.len) : (offset += 1) {
+        // Only round-trip codepoint boundaries.
+        if (offset < src.len and src[offset] & 0xC0 == 0x80) continue;
+        const pos = lsp_text.offsetToPosition(src, offset, .@"utf-16");
+        try testing.expectEqual(offset, lsp_text.positionToOffset(src, pos, .@"utf-16"));
+    }
+}
+
+test "text > applyIncrementalChange edits at the utf-16 position" {
+    const allocator = testing.allocator;
+
+    const src = "pub fn Page() zx.Component {\n    return (<p>Café </p>);\n}\n";
+    // A client using utf-16 asks to insert "x" right before `</p>`. On line 1
+    // that is column 20 in utf-16 code units, but byte 21 because of `é`.
+    const edited = try lsp_text.applyIncrementalChange(
+        allocator,
+        src,
+        .{
+            .start = .{ .line = 1, .character = 20 },
+            .end = .{ .line = 1, .character = 20 },
+        },
+        "x",
+        .@"utf-16",
+    );
+    defer allocator.free(edited);
+
+    try testing.expectEqualStrings(
+        "pub fn Page() zx.Component {\n    return (<p>Café x</p>);\n}\n",
+        edited,
+    );
+}
+
+test "text > applyIncrementalChange replaces a range" {
+    const allocator = testing.allocator;
+
+    const src = "<p>Café</p>\n";
+    const edited = try lsp_text.applyIncrementalChange(
+        allocator,
+        src,
+        .{
+            .start = .{ .line = 0, .character = 3 },
+            .end = .{ .line = 0, .character = 7 },
+        },
+        "Tea",
+        .@"utf-16",
+    );
+    defer allocator.free(edited);
+
+    try testing.expectEqualStrings("<p>Tea</p>\n", edited);
+}
+
+test "text > applyIncrementalChange rejects an inverted range" {
+    const allocator = testing.allocator;
+
+    try testing.expectError(error.InvalidRange, lsp_text.applyIncrementalChange(
+        allocator,
+        "abcdef\n",
+        .{
+            .start = .{ .line = 0, .character = 4 },
+            .end = .{ .line = 0, .character = 1 },
+        },
+        "x",
+        .@"utf-16",
+    ));
+}


### PR DESCRIPTION
## Summary

`zx lsp` treated `Position.character` as a byte offset, but LSP counts it in the code units of the encoding negotiated during `initialize` — UTF-16 unless the client asks for something else, which is what VS Code, Neovim and Helix all use.

Any `.zx` line with non-ASCII text (`<p>Café</p>`, an em dash, CJK, an emoji) therefore desynchronised the server from the editor.

## Problem

`positionToOffset` / `offsetToPosition` in `src/lsp/Handler.zig` did `i + pos.character` and `limit - line_start` — pure byte arithmetic — while `handler.offset_encoding` (the value actually negotiated in `initialize`) was never consulted.

Consequences on a line containing non-ASCII text:

- **`textDocument/hover` and `textDocument/completion`** resolve to the wrong byte, so they document the token to the left of the cursor or nothing at all.
- **Hover ranges** (`offsetToPosition`) highlight the wrong span in the editor.
- **`textDocument/didChange`** is the bad one: `applyIncrementalChange` splices the edit at the wrong byte, so the server's in-memory copy of the document silently diverges from the editor's. Every later hover/completion works on corrupted text, and the corrupted full text is what gets forwarded to ZLS, so Zig diagnostics go wrong too.
- **`textDocument/formatting`** reports an end position in bytes, so the replace range can stop short of the end of the document.

A second, encoding-independent bug in the same code: a `character` past the end of its line was added to the line start unchecked, so it spilled into the following lines instead of clamping. `{ line: 0, character: 40 }` on a 2-character first line resolved to byte 40, somewhere well below.

## Root Cause

The conversions were hand-rolled and byte-based. `lsp_kit` — already a dependency — ships `lsp.offsets.positionToIndex` / `indexToPosition`, which take an `Encoding` and clamp per line, and `Handler` already stores the negotiated encoding in `handler.offset_encoding`. The two were simply never connected.

## Solution

- New `src/lsp/text.zig` holds `positionToOffset`, `offsetToPosition` and `applyIncrementalChange`, all taking an `Encoding` and delegating the conversion to `lsp.offsets`.
- `Handler` passes `handler.offset_encoding` at every call site (hover, completion, incremental change, inlay-hint filtering, formatting).
- `applyIncrementalChange` keeps its `error.InvalidRange` path, now for an inverted range, which is the case that could actually mis-size the `@memcpy`.
- Exported from `src/lsp/root.zig` ("LSP package surface used by unit tests") so the conversions are unit-testable.

No behaviour changes for pure-ASCII documents.

## Testing

`zig build test` with Zig `0.17.0-dev.1465+8b2d0ce21` (the version pinned in CI):

- `599 pass, 0 fail, 11 skipped` (baseline on `main` was `591 pass, 0 fail, 11 skipped`)
- `zig build` succeeds
- `zig fmt --check` clean on all changed files

8 tests added to `test/cli/lsp.zig`. Re-running them against the old byte-based implementation fails 6 of the 8:

```
✗ text > positionToOffset counts utf-16 code units
✗ text > positionToOffset handles surrogate pairs
✗ text > positionToOffset clamps to the end of the line
✗ text > offsetToPosition counts utf-16 code units
✗ text > applyIncrementalChange edits at the utf-16 position
✗ text > applyIncrementalChange replaces a range
```

The other two (`offsetToPosition roundtrips through positionToOffset`, `applyIncrementalChange rejects an inverted range`) are invariants that hold either way.

The clearest one mirrors the real editing scenario — a UTF-16 client inserting `x` before `</p>` in `return (<p>Café </p>);` at column 20, which is byte 21:

| | result |
| --- | --- |
| before | `return (<p>Café</p>x);` |
| after | `return (<p>Café x</p>);` |

Coverage spans UTF-8 / UTF-16 / UTF-32, a 2-byte codepoint (`é`), a surrogate pair (`🠁`), past-end-of-line clamping, and an offset↔position round-trip over every codepoint boundary of a mixed document.

## Related Issue

Related to #101 (`fix(lsp): source mapping and auto complete issues`) — positions are the input to both halves.
