### PR TITLE
feat(ide): add Emacs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 zig-out
 zig-pkg/
 
+# Emacs
+*.elc
+
 # Project Specific
 tmp
 test/data/assets/

--- a/ide/emacs/README.md
+++ b/ide/emacs/README.md
@@ -1,0 +1,98 @@
+# Emacs
+
+`zx-ts-mode` is a tree-sitter major mode for `.zx` files. It provides syntax
+highlighting, indentation, imenu and structural navigation for both the Zig and
+the markup halves of a ZX file, plus LSP support through `zx lsp`.
+
+## Requirements
+
+- Emacs 29.1 or newer, built with tree-sitter support (`M-: (treesit-available-p)`
+  must return `t`).
+- A `libtree-sitter` of **0.25 or newer**. The ZX grammar is generated at
+  tree-sitter ABI 15, and Emacs only loads grammars up to the ABI of the
+  `libtree-sitter` it was linked against. An older build reports:
+
+  ```elisp
+  (treesit-language-available-p 'zx t)
+  ;; => (nil version-mismatch 15)
+  ```
+
+  If you hit this, use an Emacs built against a current `libtree-sitter`.
+- A C compiler, for building the grammar.
+- The `zx` CLI on `PATH` for LSP support. Inside a Ziex project the same
+  server is reachable as `zig build zx -- lsp`, so the CLI is optional.
+
+## Installation
+
+Clone the repository and point Emacs at `ide/emacs`:
+
+```elisp
+;; ~/.emacs.d/init.el
+(use-package zx-ts-mode
+  :load-path "~/src/ziex/ide/emacs"
+  :mode "\\.zx\\'")
+```
+
+With `straight.el`:
+
+```elisp
+(use-package zx-ts-mode
+  :straight (zx-ts-mode :type git :host github :repo "ziex-dev/ziex"
+                        :files ("ide/emacs/zx-ts-mode.el"))
+  :mode "\\.zx\\'")
+```
+
+Without a package manager, add the directory to `load-path` and require it:
+
+```elisp
+(add-to-list 'load-path "~/src/ziex/ide/emacs")
+(require 'zx-ts-mode)
+```
+
+## Grammar
+
+Build and install the ZX grammar once:
+
+```
+M-x zx-ts-mode-install-grammar
+```
+
+This clones `ziex-dev/ziex` and compiles `pkg/tree-sitter-zx`. The recipe lives
+in `zx-ts-mode-grammar-source` if you would rather build from a local checkout:
+
+```elisp
+(setq zx-ts-mode-grammar-source
+      '(zx "~/src/ziex" nil "pkg/tree-sitter-zx/src"))
+```
+
+## LSP
+
+`zx-ts-mode` registers itself with Eglot, so `M-x eglot` in a `.zx` buffer
+starts `zx lsp`:
+
+```elisp
+(add-hook 'zx-ts-mode-hook #'eglot-ensure)
+```
+
+Change the command with `zx-ts-mode-lsp-command`, for example to use the
+project's own build instead of an installed CLI:
+
+```elisp
+(setq zx-ts-mode-lsp-command '("zig" "build" "zx" "--" "lsp"))
+```
+
+The server handles ZX-aware completion, hover and formatting itself and
+forwards everything else to ZLS, so no diagnostic filtering is needed on the
+Emacs side.
+
+## Customization
+
+| Variable                     | Default        | Description                                |
+| ---------------------------- | -------------- | ------------------------------------------ |
+| `zx-ts-mode-indent-offset`   | `4`            | Spaces per indentation step.               |
+| `zx-ts-mode-lsp-command`     | `("zx" "lsp")` | Command Eglot uses to start the server.    |
+| `zx-ts-mode-grammar-source`  | see above      | Recipe used by `zx-ts-mode-install-grammar`. |
+
+Three faces are defined for the markup so it can be told apart from the Zig
+around it: `zx-ts-mode-tag-face`, `zx-ts-mode-attribute-face` and
+`zx-ts-mode-builtin-attribute-face`.

--- a/ide/emacs/zx-ts-mode.el
+++ b/ide/emacs/zx-ts-mode.el
@@ -27,7 +27,10 @@
 
 (require 'treesit)
 
+(declare-function treesit-node-child "treesit.c")
 (declare-function treesit-node-child-by-field-name "treesit.c")
+(declare-function treesit-node-next-sibling "treesit.c")
+(declare-function treesit-node-type "treesit.c")
 (declare-function treesit-parser-create "treesit.c")
 
 (defgroup zx nil
@@ -237,10 +240,19 @@
 ;;; Navigation
 
 (defun zx-ts-mode--defun-name (node)
-  "Return the name of NODE for imenu and `which-function-mode'."
-  (treesit-node-text
-   (treesit-node-child-by-field-name node "name")
-   t))
+  "Return the name of NODE for imenu and `which-function-mode'.
+`function_declaration' exposes a `name' field.  `test_declaration'
+does not; its title is a `string' or `identifier' child."
+  (let ((name-node (treesit-node-child-by-field-name node "name")))
+    (when (and (null name-node)
+               (equal (treesit-node-type node) "test_declaration"))
+      (let ((child (treesit-node-child node 0 t)))
+        (while (and child
+                    (not (member (treesit-node-type child)
+                                 '("string" "identifier"))))
+          (setq child (treesit-node-next-sibling child t)))
+        (setq name-node child)))
+    (and name-node (treesit-node-text name-node t))))
 
 ;;; Eglot
 

--- a/ide/emacs/zx-ts-mode.el
+++ b/ide/emacs/zx-ts-mode.el
@@ -1,0 +1,314 @@
+;;; zx-ts-mode.el --- Major mode for Ziex (ZX) -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Ziex contributors
+
+;; Author: Ziex contributors
+;; URL: https://github.com/ziex-dev/ziex
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "29.1"))
+;; Keywords: languages, zig, web
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Major mode for ZX, the markup-in-Zig language of the Ziex web framework
+;; (https://ziex.dev).  It is backed by the tree-sitter grammar that lives in
+;; `pkg/tree-sitter-zx' of the Ziex repository and provides font locking,
+;; indentation, imenu and structural navigation for both the Zig and the
+;; markup halves of a `.zx' file.
+;;
+;; Install the grammar once with `M-x zx-ts-mode-install-grammar'.
+;;
+;; Language server support comes from `zx lsp' via Eglot; the entry is added
+;; to `eglot-server-programs' when Eglot is loaded.  See ide/emacs/README.md
+;; for the full setup, including the libtree-sitter version ZX needs.
+
+;;; Code:
+
+(require 'treesit)
+
+(declare-function treesit-node-child-by-field-name "treesit.c")
+(declare-function treesit-parser-create "treesit.c")
+
+(defgroup zx nil
+  "Major mode for editing ZX files."
+  :group 'languages
+  :prefix "zx-ts-mode-")
+
+(defcustom zx-ts-mode-indent-offset 4
+  "Number of spaces for each indentation step in `zx-ts-mode'."
+  :type 'integer
+  :safe #'integerp)
+
+(defcustom zx-ts-mode-lsp-command '("zx" "lsp")
+  "Command that starts the ZX language server for Eglot."
+  :type '(repeat string))
+
+;;; Faces
+
+(defface zx-ts-mode-tag-face
+  '((t :inherit font-lock-function-name-face))
+  "Face for ZX element tag names.")
+
+(defface zx-ts-mode-attribute-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for ZX element attribute names.")
+
+(defface zx-ts-mode-builtin-attribute-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for ZX builtin attribute names such as `@allocator'.")
+
+;;; Grammar
+
+(defvar zx-ts-mode-grammar-source
+  '(zx "https://github.com/ziex-dev/ziex" "main" "pkg/tree-sitter-zx/src")
+  "Recipe for `treesit-language-source-alist' that builds the ZX grammar.")
+
+;;;###autoload
+(defun zx-ts-mode-install-grammar ()
+  "Build and install the ZX tree-sitter grammar."
+  (interactive)
+  (let ((treesit-language-source-alist (list zx-ts-mode-grammar-source)))
+    (treesit-install-language-grammar 'zx)))
+
+;;; Font lock
+
+(defvar zx-ts-mode--keywords
+  '("asm" "const" "defer" "errdefer" "error" "test" "var")
+  "Zig keywords with no more specific `zx-ts-mode' category.")
+
+(defvar zx-ts-mode--type-keywords
+  '("enum" "opaque" "struct" "union")
+  "Zig keywords that introduce a container type.")
+
+(defvar zx-ts-mode--modifier-keywords
+  '("addrspace" "align" "allowzero" "callconv" "comptime" "export" "extern"
+    "inline" "linksection" "noalias" "noinline" "packed" "pub" "threadlocal"
+    "usingnamespace" "volatile")
+  "Zig declaration modifiers.")
+
+(defvar zx-ts-mode--control-keywords
+  '("async" "await" "break" "catch" "continue" "else" "for" "if" "nosuspend"
+    "resume" "return" "suspend" "switch" "try" "while")
+  "Zig control-flow keywords.")
+
+(defvar zx-ts-mode--operator-keywords
+  '("and" "or" "orelse")
+  "Zig operators spelled as words.")
+
+(defvar zx-ts-mode--operators
+  '("=" "*=" "*%=" "*|=" "/=" "%=" "+=" "+%=" "+|=" "-=" "-%=" "-|=" "<<="
+    "<<|=" ">>=" "&=" "^=" "|=" "!" "~" "-" "-%" "&" "==" "!=" ">" ">=" "<="
+    "<" "^" "|" "<<" ">>" "<<|" "+" "++" "+%" "*" "/" "%" "**" "*%" "*|" "||"
+    ".*" ".?" "?" "..")
+  "Zig operators.")
+
+(defvar zx-ts-mode--font-lock-settings
+  (treesit-font-lock-rules
+   :language 'zx
+   :feature 'comment
+   '((comment) @font-lock-comment-face
+     ((comment) @font-lock-doc-face
+      (:match "\\`//[/!]" @font-lock-doc-face)))
+
+   :language 'zx
+   :feature 'definition
+   '((function_declaration name: (identifier) @font-lock-function-name-face)
+     (parameter name: (identifier) @font-lock-variable-name-face)
+     (container_field name: (identifier) @font-lock-property-name-face)
+     (payload (identifier) @font-lock-variable-name-face))
+
+   :language 'zx
+   :feature 'keyword
+   `([,@zx-ts-mode--keywords
+      ,@zx-ts-mode--type-keywords
+      ,@zx-ts-mode--modifier-keywords
+      ,@zx-ts-mode--control-keywords
+      ,@zx-ts-mode--operator-keywords
+      "fn"]
+     @font-lock-keyword-face)
+
+   :language 'zx
+   :feature 'string
+   '((character) @font-lock-string-face
+     (string) @font-lock-string-face
+     (multiline_string) @font-lock-string-face)
+
+   :language 'zx
+   :feature 'type
+   '((builtin_type) @font-lock-type-face
+     "anyframe" @font-lock-type-face
+     (parameter type: (identifier) @font-lock-type-face)
+     ((identifier) @font-lock-type-face
+      (:match "\\`[A-Z][A-Za-z0-9_]*\\'" @font-lock-type-face)))
+
+   :language 'zx
+   :feature 'tag
+   '((zx_tag_name) @zx-ts-mode-tag-face
+     ["<" ">" "</" "/>"] @font-lock-bracket-face)
+
+   :language 'zx
+   :feature 'attribute
+   '((zx_attribute_name) @zx-ts-mode-attribute-face
+     (zx_builtin_name) @zx-ts-mode-builtin-attribute-face
+     (zx_attribute_value) @font-lock-string-face
+     (zx_template_content) @font-lock-string-face
+     (zx_shorthand_attribute (identifier) @zx-ts-mode-attribute-face)
+     (zx_builtin_shorthand_attribute
+      name: (identifier) @zx-ts-mode-builtin-attribute-face))
+
+   :language 'zx
+   :feature 'builtin
+   '((builtin_identifier) @font-lock-builtin-face
+     ((identifier) @font-lock-builtin-face
+      (:equal "_" @font-lock-builtin-face)))
+
+   :language 'zx
+   :feature 'constant
+   '([(boolean) "null" "undefined" "unreachable"] @font-lock-constant-face
+     ((identifier) @font-lock-constant-face
+      (:match "\\`[A-Z][A-Z0-9_]+\\'" @font-lock-constant-face)))
+
+   :language 'zx
+   :feature 'escape-sequence
+   :override t
+   '((escape_sequence) @font-lock-escape-face)
+
+   :language 'zx
+   :feature 'number
+   '([(integer) (float)] @font-lock-number-face)
+
+   :language 'zx
+   :feature 'property
+   '((field_expression member: (identifier) @font-lock-property-use-face))
+
+   :language 'zx
+   :feature 'function
+   '((call_expression function: (identifier) @font-lock-function-call-face)
+     (call_expression
+      function: (field_expression member: (identifier) @font-lock-function-call-face)))
+
+   :language 'zx
+   :feature 'operator
+   `([,@zx-ts-mode--operators] @font-lock-operator-face)
+
+   :language 'zx
+   :feature 'bracket
+   '(["(" ")" "[" "]" "{" "}"] @font-lock-bracket-face)
+
+   :language 'zx
+   :feature 'delimiter
+   '([";" "." "," ":" "=>" "->"] @font-lock-delimiter-face)
+
+   :language 'zx
+   :feature 'error
+   :override t
+   '((ERROR) @font-lock-warning-face))
+  "Tree-sitter font-lock settings for `zx-ts-mode'.")
+
+;;; Indentation
+
+(defvar zx-ts-mode--indent-rules
+  `((zx
+     ((parent-is "source_file") column-0 0)
+     ((node-is "}") standalone-parent 0)
+     ((node-is ")") standalone-parent 0)
+     ((node-is "]") standalone-parent 0)
+     ((node-is "else_clause") standalone-parent 0)
+     ;; A closing tag lines up with the element it closes.
+     ((node-is "zx_end_tag") parent-bol 0)
+     ;; Markup children and attributes are indented inside their tag.
+     ((parent-is "zx_element") parent-bol zx-ts-mode-indent-offset)
+     ((parent-is "zx_fragment") parent-bol zx-ts-mode-indent-offset)
+     ((parent-is "zx_start_tag") parent-bol zx-ts-mode-indent-offset)
+     ((parent-is "zx_self_closing_element") parent-bol zx-ts-mode-indent-offset)
+     ((parent-is "zx_block") parent-bol zx-ts-mode-indent-offset)
+     ((parent-is "zx_child") parent-bol 0)
+     ;; Zig.
+     ((parent-is "block") standalone-parent zx-ts-mode-indent-offset)
+     ((parent-is "switch_expression") standalone-parent zx-ts-mode-indent-offset)
+     ((parent-is "initializer_list") standalone-parent zx-ts-mode-indent-offset)
+     ((parent-is "arguments") standalone-parent zx-ts-mode-indent-offset)
+     ((parent-is "parameters") standalone-parent zx-ts-mode-indent-offset)
+     ((parent-is "parenthesized_expression") standalone-parent zx-ts-mode-indent-offset)
+     (catch-all parent-bol 0)))
+  "Tree-sitter indentation rules for `zx-ts-mode'.")
+
+;;; Navigation
+
+(defun zx-ts-mode--defun-name (node)
+  "Return the name of NODE for imenu and `which-function-mode'."
+  (treesit-node-text
+   (treesit-node-child-by-field-name node "name")
+   t))
+
+;;; Eglot
+
+(defun zx-ts-mode-eglot-contact (&optional _interactive)
+  "Return the ZX language server command for Eglot.
+Reads `zx-ts-mode-lsp-command' on every connection, so customizing it
+takes effect without reloading."
+  zx-ts-mode-lsp-command)
+
+(with-eval-after-load 'eglot
+  (when (boundp 'eglot-server-programs)
+    (add-to-list 'eglot-server-programs
+                 '(zx-ts-mode . zx-ts-mode-eglot-contact))))
+
+;;; Mode
+
+(defvar zx-ts-mode--syntax-table
+  (let ((table (make-syntax-table)))
+    ;; Zig comments: `//' to end of line.
+    (modify-syntax-entry ?/ ". 12" table)
+    (modify-syntax-entry ?\n ">" table)
+    (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\\ "\\" table)
+    (modify-syntax-entry ?_ "_" table)
+    (modify-syntax-entry ?@ "'" table)
+    (dolist (char '(?+ ?- ?* ?% ?& ?| ?^ ?! ?= ?< ?> ?~ ??))
+      (modify-syntax-entry char "." table))
+    table)
+  "Syntax table for `zx-ts-mode'.")
+
+;;;###autoload
+(define-derived-mode zx-ts-mode prog-mode "ZX"
+  "Major mode for editing ZX files, powered by tree-sitter.
+
+\\{zx-ts-mode-map}"
+  :syntax-table zx-ts-mode--syntax-table
+
+  (setq-local comment-start "// ")
+  (setq-local comment-end "")
+  (setq-local comment-start-skip "//+[ \t]*")
+
+  (if (not (treesit-ready-p 'zx))
+      (message "ZX tree-sitter grammar is missing; run M-x zx-ts-mode-install-grammar")
+
+    (treesit-parser-create 'zx)
+
+    (setq-local treesit-font-lock-settings zx-ts-mode--font-lock-settings)
+    (setq-local treesit-font-lock-feature-list
+                '((comment definition)
+                  (keyword string type tag)
+                  (attribute builtin constant escape-sequence number property)
+                  (bracket delimiter function operator error)))
+
+    (setq-local treesit-simple-indent-rules zx-ts-mode--indent-rules)
+    (setq-local indent-tabs-mode nil)
+
+    (setq-local treesit-defun-type-regexp
+                "\\`\\(?:function_declaration\\|test_declaration\\)\\'")
+    (setq-local treesit-defun-name-function #'zx-ts-mode--defun-name)
+    (setq-local treesit-simple-imenu-settings
+                '(("Function" "\\`function_declaration\\'" nil nil)
+                  ("Test" "\\`test_declaration\\'" nil nil)))
+
+    (treesit-major-mode-setup)))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.zx\\'" . zx-ts-mode))
+
+(provide 'zx-ts-mode)
+
+;;; zx-ts-mode.el ends here

--- a/site/app/assets/docs.css
+++ b/site/app/assets/docs.css
@@ -1642,7 +1642,8 @@ code[class*="language-"] {
 #tab-editor-vscode:checked~.simple-tab-label[for="tab-editor-vscode"],
 #tab-editor-neovim:checked~.simple-tab-label[for="tab-editor-neovim"],
 #tab-editor-helix:checked~.simple-tab-label[for="tab-editor-helix"],
-#tab-editor-zed:checked~.simple-tab-label[for="tab-editor-zed"] {
+#tab-editor-zed:checked~.simple-tab-label[for="tab-editor-zed"],
+#tab-editor-emacs:checked~.simple-tab-label[for="tab-editor-emacs"] {
     color: var(--link-color);
     border-bottom-color: var(--link-color);
     border-bottom-width: 2px;
@@ -1663,7 +1664,8 @@ div:has(#tab-control-while:checked) #control-content-while,
 div:has(#tab-editor-vscode:checked) #content-editor-vscode,
 div:has(#tab-editor-neovim:checked) #content-editor-neovim,
 div:has(#tab-editor-helix:checked) #content-editor-helix,
-div:has(#tab-editor-zed:checked) #content-editor-zed {
+div:has(#tab-editor-zed:checked) #content-editor-zed,
+div:has(#tab-editor-emacs:checked) #content-editor-emacs {
     display: block;
 }
 

--- a/site/app/pages/learn/page.zx
+++ b/site/app/pages/learn/page.zx
@@ -397,10 +397,12 @@ fn EditorSetup(allocator: zx.Allocator) zx.Component {
                     <input type="radio" id="tab-editor-neovim" name="editor-setup" class="simple-tab-radio" aria-label="Neovim" />
                     <input type="radio" id="tab-editor-helix" name="editor-setup" class="simple-tab-radio" aria-label="Helix" />
                     <input type="radio" id="tab-editor-zed" name="editor-setup" class="simple-tab-radio" aria-label="Zed" />
+                    <input type="radio" id="tab-editor-emacs" name="editor-setup" class="simple-tab-radio" aria-label="Emacs" />
                     <label for="tab-editor-vscode" class="simple-tab-label">VS Code</label>
                     <label for="tab-editor-neovim" class="simple-tab-label">Neovim</label>
                     <label for="tab-editor-helix" class="simple-tab-label">Helix</label>
                     <label for="tab-editor-zed" class="simple-tab-label">Zed</label>
+                    <label for="tab-editor-emacs" class="simple-tab-label">Emacs</label>
                 </div>
                 <div class="simple-tab-content" id="content-editor-vscode">
                     <p>Install the official ZX extension for the best development experience.</p>
@@ -430,6 +432,11 @@ fn EditorSetup(allocator: zx.Allocator) zx.Component {
                         <li>Navigate to <code>ide/zed</code> in the cloned repo</li>
                     </ol>
                     <p>See the <a href=`{zx.info.repository}/tree/main/ide/zed` target="_blank" rel="noopener noreferrer">Zed setup guide</a> for details.</p>
+                </div>
+                <div class="simple-tab-content" id="content-editor-emacs">
+                    <p>Add <code>ide/emacs</code> from a checkout to your <code>load-path</code> and run <code>M-x zx-ts-mode-install-grammar</code> once to build the grammar.</p>
+                    <p>See the <a href=`{zx.info.repository}/tree/main/ide/emacs` target="_blank" rel="noopener noreferrer">Emacs setup guide</a> for the full configuration, including the required <code>libtree-sitter</code> version.</p>
+                    <p><strong>Features:</strong> Tree-sitter syntax highlighting, indentation, imenu, and LSP support via Eglot.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Adds `ide/emacs/` — a tree-sitter major mode for `.zx` files — so Emacs joins VS Code, Neovim, Helix and Zed. It covers the two things you said in #120 an editor needs, Tree-Sitter and LSP:

- font locking over the whole grammar (Zig **and** the ZX markup), indentation, imenu and defun navigation
- `M-x zx-ts-mode-install-grammar` to build the grammar out of `pkg/tree-sitter-zx`
- `zx lsp` registered with Eglot

Plus an Emacs tab in the Editor Setup section of the learn page.

## Problem

`.zx` files open in `fundamental-mode` in Emacs. There is no grammar recipe, no LSP wiring, and nothing in the docs pointing Emacs users anywhere. Unlike Neovim and Helix, Emacs cannot be set up from configuration alone — `treesit` font-lock and indentation are defined in Lisp, so a mode file is required.

## Solution

**`ide/emacs/zx-ts-mode.el`** (314 lines, `emacs "29.1"`):

- **Font lock** — 17 rules across four `treesit-font-lock-feature-list` levels. The Zig half follows `pkg/tree-sitter-zx/queries/highlights.scm`; the ZX half covers `zx_tag_name`, `zx_attribute_name`, `zx_builtin_name`, `zx_attribute_value`, `zx_template_content` and both shorthand attribute forms (`{class}`, `@{allocator}`).
- **Indentation** — Zig blocks, switches, initializer lists, arguments and parameters, plus markup: children indent inside their tag and `zx_end_tag` lines up with the element it closes. Step size is `zx-ts-mode-indent-offset` (default 4).
- **Navigation** — imenu for functions and tests, `treesit-defun-type-regexp` and `treesit-defun-name-function`.
- **Grammar** — `zx-ts-mode-install-grammar` installs from `pkg/tree-sitter-zx/src`; the recipe is exposed as `zx-ts-mode-grammar-source` so it can point at a local checkout.
- **LSP** — Eglot gets `(zx-ts-mode . zx-ts-mode-eglot-contact)`, a function so `zx-ts-mode-lsp-command` stays customizable after load. No diagnostic filtering is needed the way Helix and Neovim need it for raw `zls`, because `zx lsp` nulls out the backing server's `publishDiagnostics` and publishes its own.
- Three faces (`zx-ts-mode-tag-face`, `-attribute-face`, `-builtin-attribute-face`) so markup is distinguishable from the Zig around it.

**One thing worth flagging:** `pkg/tree-sitter-zx/src/parser.c` is `LANGUAGE_VERSION 15`, and Emacs only loads grammars up to the ABI of the `libtree-sitter` it was linked against. On Emacs 29.3 with libtree-sitter 0.20.8 the grammar builds and installs fine but then reports:

```elisp
(treesit-language-available-p 'zx t)
;; => (nil version-mismatch 15)
```

So Emacs has to be linked against libtree-sitter 0.25 or newer. That is documented in the README requirements rather than worked around.

## Testing

Checked against GNU Emacs 29.3 (`treesit-available-p` → `t`):

- **Byte-compiles clean** with `byte-compile-error-on-warn t` — zero warnings.
- **`checkdoc`** reports no style warnings.
- **Loads and wires up correctly**:

  ```
  mode defined:        t
  derives from:        prog-mode
  auto-mode .zx:       zx-ts-mode
  eglot entry:         zx-ts-mode-eglot-contact
  eglot contact:       (zx lsp)
  font-lock features:  17
  indent rules:        19
  ```

- **Grammar recipe works end to end** — `zx-ts-mode-install-grammar` against a local checkout printed `Cloning repository` / `Compiling library` / `Library installed to ~/.emacs.d/tree-sitter/libtree-sitter-zx.so`, confirming `pkg/tree-sitter-zx/src` is the right `SOURCE-DIR`. Loading it then hit the expected `version-mismatch: 15` above.

- **Every font-lock query was checked against the real grammar.** Each query was expanded with `treesit-query-expand`, then compiled and run with `ts_query_new` + `ts_query_cursor` against `pkg/tree-sitter-zx/src/parser.c` (ABI 15) built on the vendored tree-sitter runtime. All 17 compile, and every capture matches on a `.zx` sample covering components, control flow, attributes, shorthands, template attributes, doc comments, escapes and tests — for example:

  ```
  05-tag.scm         query ok: 2 patterns, 2 captures   zx-ts-mode-tag-face 16, font-lock-bracket-face 33
  06-attribute.scm   query ok: 6 patterns, 3 captures   zx-ts-mode-attribute-face 8, builtin 2, string 7
  01-definition.scm  query ok: 4 patterns, 3 captures   function-name 2, variable-name 2, property-name 2
  ```

  `16-error.scm` matches 0 on the clean sample and 2 on a deliberately broken one, as intended. Emacs spells its predicates `#match` / `#equal`, so those were normalized to `#match?` / `#eq?` for the vanilla tree-sitter parser; the node types, fields and capture placement — the parts that can actually be wrong — are what this verifies.

- **Indent rules cross-checked** — every node type they reference (`zx_element`, `zx_end_tag`, `zx_start_tag`, `zx_block`, `zx_child`, `zx_fragment`, `zx_self_closing_element`, `block`, `switch_expression`, `initializer_list`, `arguments`, `parameters`, `parenthesized_expression`, `else_clause`, `source_file`, and the `}` `)` `]` tokens) exists in `node-types.json` / `grammar.json`; none are dead rules.

- **Docs page** — `zx transpile site/app/pages/learn/page.zx` succeeds and `zx fmt --stdout` leaves it byte-identical. The tab CSS in `docs.css` enumerates tab ids explicitly, so `#tab-editor-emacs` was added to both selector lists.

- `zig build` and `zig build test` with Zig `0.17.0-dev.1465+8b2d0ce21`: `591 pass, 0 fail, 11 skipped`, unchanged from `main` (this PR touches no Zig code).

**What I could not test:** live fontification and indentation in a real buffer, because Emacs 29.3 cannot load an ABI 15 grammar. The queries and the rules' node types are verified against the grammar as described, but if you have an Emacs linked against a newer libtree-sitter, a visual pass would be worth doing before merging.

## Related Issue

Closes #120. Also ticks the Emacs box for #136 (`feat: ide support`).
